### PR TITLE
Read json file in text mode to support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: 'python'
-python: '2.7'
+python:
+  - '2.7'
+  - '3.4'
 
 before_install:
   - 'pip install setuptools flake8 pytest'

--- a/flask_webpack/__init__.py
+++ b/flask_webpack/__init__.py
@@ -46,7 +46,7 @@ class Webpack(object):
         webpack_stats = app.config['WEBPACK_MANIFEST_PATH']
 
         try:
-            with app.open_resource(webpack_stats) as stats_json:
+            with app.open_resource(webpack_stats, 'r') as stats_json:
                 stats = json.load(stats_json)
 
                 if app.config['WEBPACK_ASSETS_URL']:

--- a/flask_webpack/tests/test_app/tests/test_views.py
+++ b/flask_webpack/tests/test_app/tests/test_views.py
@@ -8,7 +8,8 @@ def test_index_page(client):
     js = 'app_js.8b7c0de88caa3f366b53.js'
     image = 'images/dog/no-idea.b9252d5fd8f39ce3523d303144338d7b.jpg'
 
-    assert asset_path in response.data
-    assert css in response.data
-    assert js in response.data
-    assert image in response.data
+    response_data = response.data.decode('utf-8')
+    assert asset_path in response_data
+    assert css in response_data
+    assert js in response_data
+    assert image in response_data


### PR DESCRIPTION
The Flask `open_resource()` helper function will [open files in binary mode by default](https://github.com/mitsuhiko/flask/blob/7f3867491570746a4c14bdaa5bd59ec1b64cbfea/flask/helpers.py#L875). In Python 3, `json.load()` can only load files opened in text mode. This pull request makes `open_resource()` use text mode to open the webpack json file. It also changes the view unit test to decode the response data to unicode (again to support Python 3) and adds Travis CI testing for Python 3.4.
