### PR TITLE
Added missing dependency file-loader

### DIFF
--- a/flask_webpack/tests/test_app/package.json
+++ b/flask_webpack/tests/test_app/package.json
@@ -4,6 +4,7 @@
     "build": "node_modules/.bin/webpack --progress --profile --colors"
   },
   "dependencies": {
+    "file-loader": "^0.8.5",
     "script-loader": "^0.6.1",
     "css-loader": "^0.14.4",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
Fixes webpack error _cannot resolve module 'file_' when running `npm install && npm start` with nodejs 4.4.5 in `flask_webpack/tests/test_app`
