### PR TITLE
`WEBPACK_MANIFEST_ASSETS_ONLY` - support simple manifest files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,11 @@ options:
     - **Optional:** Use this asset url instead of the ``publicPath``.
     - You would set this to your full domain name or CDN in production.
 
+- ``WEBPACK_MANIFEST_ASSETS_ONLY``: default ``False``
+    - **Optional:** Assume the manifest file only contains the assets, instead of them
+    being inside an "assets" object.
+
+
 Learn more
 ^^^^^^^^^^
 

--- a/flask_webpack/__init__.py
+++ b/flask_webpack/__init__.py
@@ -57,13 +57,16 @@ class Webpack(object):
         try:
             with app.open_resource(webpack_stats, 'r') as stats_json:
                 stats = json.load(stats_json)
+                public_path = '/'
 
-                if app.config['WEBPACK_ASSETS_URL']:
-                    self.assets_url = app.config['WEBPACK_ASSETS_URL']
+                if app.config.get('WEBPACK_MANIFEST_ASSETS_ONLY') is True:
+                    self.assets = stats
                 else:
-                    self.assets_url = stats['publicPath']
+                    self.assets = stats['assets']
+                    public_path = stats.get('publicPath') or public_path
 
-                self.assets = stats['assets']
+                self.assets_url = (app.config.get('WEBPACK_ASSETS_URL')
+                                   or public_path)
         except IOError:
             raise RuntimeError(
                 "Flask-Webpack requires 'WEBPACK_MANIFEST_PATH' to be set and "

--- a/flask_webpack/tests/test_app/app.py
+++ b/flask_webpack/tests/test_app/app.py
@@ -37,5 +37,6 @@ app = create_app()
 def index():
     return render_template('index.jinja2')
 
+
 if __name__ == '__main__':
     run_simple('localhost', 5000, app, use_reloader=True, use_debugger=True)


### PR DESCRIPTION
Adds support for manifest files output with webpack-manifest-plugin
(https://www.npmjs.com/package/webpack-manifest-plugin)